### PR TITLE
feat: enable LOCK_TO_SINGLE_CONVERSATION setting for meta inbox

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -589,7 +589,9 @@ export default {
       return this.inbox.name;
     },
     canLocktoSingleConversation() {
-      return this.isASmsInbox || this.isAWhatsAppChannel;
+      return (
+        this.isASmsInbox || this.isAWhatsAppChannel || this.isAFacebookInbox
+      );
     },
     inboxNameLabel() {
       if (this.isAWebWidgetInbox) {


### PR DESCRIPTION
# Proposal to extend Lock to Single Conversation Feature to Meta Inbox.

## Description

The objective of this feature is to introduce the ability to lock conversations to a single thread for Instagram messages within the Meta inbox, mirroring existing functionality in WhatsApp and SMS inboxes. 

### Proposed Changes:

**1. Frontend Setting for Meta Inbox**:

- Enable setting in the frontend UI for the Meta inbox, similar to the existing settings for WhatsApp and SMS inboxes.
- This setting allows users to enable or disable the lock to a single conversation feature for Instagram messages.
- Changing this setting updates a flag in the database directly, requiring no alterations to backend logic. 
(Already commited the relevant vue changes)

**2. Backend Changes in Message Handling**:
- Modify the conversation method within `app/builders/messages/instagram/message_builder.rb` to incorporate the lock to a single conversation logic.
- This method, invoked by build_message during the processing of Instagram message events from the webhook, determines the @conversation variable's value.
- Implement a two-step approach based on the lock_to_single_conversation flag status:
  - If enabled, search for an existing instagram_direct_message conversation with specified parameters. If not found, create a new conversation.
  - If disabled, fetch the last conversation with the given parameters. If this conversation is marked as resolved, initiate a new conversation; otherwise, continue with the existing one.
  
- The new method will look like:
   ```app/builders/messages/instagram/message_builder.rb
  def conversation
    @conversation ||= begin
      lock_to_single_conversation = @inbox.lock_to_single_conversation

      if lock_to_single_conversation
        Conversation.where(conversation_params).find_by(
          "additional_attributes ->> 'type' = 'instagram_direct_message'"
        ) || build_conversation
      else
        # If lock to single conversation is disabled, we will create a new conversation if previous conversation is resolved
        last_conversation = Conversation.where(conversation_params).order(created_at: :desc).first
        if last_conversation&.status == 'resolved'
          build_conversation
        else
          last_conversation
        end
      end
    end
  end
   ```
@pranavrajs if you review the approach, i will make the relevant changes.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
