### PR TITLE
intercom: don't show the chat bubble for CSAT links when there is no user logged in

### DIFF
--- a/config/initializers/intercom.rb
+++ b/config/initializers/intercom.rb
@@ -35,7 +35,7 @@ IntercomRails.config do |config|
   # == Include for logged out Users
   # If set to true, include the Intercom messenger on all pages, regardless of whether
   # The user model class (set below) is present.
-  config.include_for_logged_out_users = true
+  config.include_for_logged_out_users = false
 
   # == User model class
   # The class which defines your user model


### PR DESCRIPTION
as title says, its a one line change

tests seem to be broken on `bitespeed-develop` right now, so not specifically this branch.. worth exploring later