### PR TITLE
fix: bugs raised by levitico

### DIFF
--- a/app/builders/messages/facebook/message_builder.rb
+++ b/app/builders/messages/facebook/message_builder.rb
@@ -119,8 +119,15 @@ class Messages::Facebook::MessageBuilder < Messages::Messenger::MessageBuilder
   end
 
   def process_contact_params_result(result)
+    full_name = if result['first_name'] || result['last_name']
+                  "#{result['first_name'] || 'John'} #{result['last_name'] || 'Doe'}"
+                elsif result['name']
+                  result['name']
+                else
+                  'John Doe'
+                end
     {
-      name: "#{result['first_name'] || 'John'} #{result['last_name'] || 'Doe'}",
+      name: full_name,
       account_id: @inbox.account_id,
       avatar_url: result['profile_pic']
     }

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -82,7 +82,7 @@ class Attachment < ApplicationRecord
       height: file.metadata[:height]
     }
 
-    metadata[:data_url] = metadata[:thumb_url] = external_url if message.inbox.instagram?
+    metadata[:data_url] = metadata[:thumb_url] = external_url if message.inbox.instagram? && message.sender_type == 'Contact'
     metadata
   end
 


### PR DESCRIPTION
- When inbound message is sent by a fb page to messenger inbox, its name used to be John Doe, now its fixed
- In instagram inbox, for outbound messages the attachment used to be null, now its fixed