### PR TITLE
fix for number text with period getting hidden

### DIFF
--- a/app/javascript/shared/helpers/MessageFormatter.js
+++ b/app/javascript/shared/helpers/MessageFormatter.js
@@ -30,6 +30,12 @@ const imgResizeManager = md => {
   });
 };
 
+const escapePeriodInNumbers = md => {
+  md.core.ruler.before('normalize', 'escape_period_in_numbers', state => {
+    state.src = state.src.replace(/(\d+)\./g, '$1\\.');
+  });
+};
+
 const md = require('markdown-it')({
   html: false,
   xhtmlOut: true,
@@ -42,6 +48,7 @@ const md = require('markdown-it')({
 })
   .use(mentionPlugin)
   .use(imgResizeManager)
+  .use(escapePeriodInNumbers)
   .use(mila, {
     attrs: {
       class: 'link',


### PR DESCRIPTION
# Pull Request Template

## Description
Jira ticket: https://bitespeed.atlassian.net/browse/CUS-5293

The issue was that whenever a user added a number followed by a dot, it was being converted into a list item when the text was rendered as HTML using Markdown-it. This behavior was not always desired, as sometimes the intention was to have a literal period after the number, not a list item.

To address this, the escapePeriodInNumbers function was created. This function adds a backslash (\\) before the period in such cases, preventing the Markdown parser from converting it into a list item.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
