### PR TITLE
feat: moved destroy message api under accounts

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -43,19 +43,6 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
     end
   end
 
-  def destroy_with_source_id
-    @message = message_via_source_id
-    if @message
-      ActiveRecord::Base.transaction do
-        @message.attachments.destroy_all
-        @message.destroy!
-      end
-      render json: { message: 'Message deleted' }, status: :ok
-    else
-      render json: { error: 'Message not found' }, status: :not_found
-    end
-  end
-
   def retry
     return if message.blank?
 

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -56,6 +56,21 @@ class Api::V1::AccountsController < Api::BaseController
     head :ok
   end
 
+  def delete_messages_with_source_id
+    messages = Message.where(account_id: params[:id], source_id: params[:source_id])
+    if messages.empty?
+      render json: { error: 'Message not found' }, status: :not_found
+    else
+      ActiveRecord::Base.transaction do
+        messages.each do |message|
+          message.attachments.destroy_all
+          message.destroy
+        end
+      end
+      render json: { success: true }, status: :ok
+    end
+  end
+
   private
 
   def ensure_account_name

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -19,6 +19,10 @@ class AccountPolicy < ApplicationPolicy
     true
   end
 
+  def delete_messages_with_source_id?
+    true
+  end
+
   def subscription?
     @account_user.administrator?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
         member do
           post :update_active_at
           get :cache_keys
+          post :delete_messages_with_source_id
         end
 
         scope module: :accounts do
@@ -91,7 +92,6 @@ Rails.application.routes.draw do
                   post :translate
                   post :retry
                   patch :update_with_source_id
-                  delete :destroy_with_source_id
                 end
               end
               resources :assignments, only: [:create]


### PR DESCRIPTION
## Why

Update the API endpoints related to message deletion for better organization and consistency within the codebase.

## What

Moved the `destroy_with_source_id` method from `app/controllers/api/v1/accounts/conversations/messages_controller.rb` to a new `delete_messages_with_source_id` method in `app/controllers/api/v1/accounts_controller.rb` to centralize message deletion functionality under the accounts section. Refactored the method to handle multiple messages with the same `source_id`.

## Potential Risks

Need to merge this before we merge the [monorepo PR](https://github.com/BiteSpeed-Dev/bitespeed-monorepo/pull/2071) or that would break.
