### PR TITLE
feat: agent wise label and agent reports

### DIFF
--- a/app/controllers/devise_overrides/token_validations_controller.rb
+++ b/app/controllers/devise_overrides/token_validations_controller.rb
@@ -6,5 +6,27 @@ class DeviseOverrides::TokenValidationsController < DeviseTokenAuth::TokenValida
     else
       render_validate_token_error
     end
+    # Rails.logger.info("Token validated for user #{@resource.inspect}")
+    # # get all the user's accounts
+    # accounts = @resource.accounts
+    # Rails.logger.info("User's accounts: #{accounts.inspect}")
+
+    # # get all user account ids
+    # account_ids = accounts.pluck(:id)
+
+    # # make a request to 'localhost:3001/csdb/auth/verify?accountId=123 and ifs successful, render the token or else invalidate the token
+    # account_ids.each do |account_id|
+    #   response = HTTParty.get("http://localhost:3003/prod/csdb/auth/verify?accountId=#{account_id}")
+    #   if response.success?
+    # render 'devise/token', formats: [:json]
+    #     else
+    #       # error out with 401 status
+    #       render json: { error: 'Unauthorized' }, status: :unauthorized
+    #       return
+    #     end
+    #   end
+    # else
+    #   render_validate_token_error
+    # end
   end
 end

--- a/app/jobs/daily_inbox_report_job.rb
+++ b/app/jobs/daily_inbox_report_job.rb
@@ -1,0 +1,166 @@
+require 'json'
+require 'csv'
+
+class DailyInboxReportJob < ApplicationJob
+  queue_as :scheduled_jobs
+
+  # TODO: [P0] fix why numbers not visible in the report
+
+  # TODO: add new .json file for label wise report
+  # JOB_DATA_URL = 'https://bitespeed-app.s3.amazonaws.com/InternalAccess/cw-auto-conversation-report.json'.freeze
+
+  def perform
+    set_statement_timeout
+
+    # fetching the job data from the URL
+    # response = HTTParty.get(JOB_DATA_URL)
+    # job_data = JSON.parse(response.body, symbolize_names: true)
+    job_data = [{
+      account_id: 785,
+      frequency: 'weekly'
+    }]
+
+    job_data.each do |job|
+      current_date = Date.current
+      current_date.wday
+
+      # should trigger only on Mondays
+      # next if job[:frequency] == 'weekly' && current_day != 1
+
+      current_date = Date.current
+
+      range = if job[:frequency] == 'weekly'
+                { since: 1.week.ago.beginning_of_day, until: 1.day.ago.end_of_day }
+              else
+                { since: 1.day.ago.beginning_of_day, until: 1.day.ago.end_of_day }
+              end
+
+      process_account(job[:account_id], current_date, range, false, job[:frequency])
+    end
+  end
+  # def generate_custom_report(account_id, range, bitespeed_bot)
+  #   set_statement_timeout
+
+  #   current_date = Date.current
+
+  #   process_account(account_id, current_date, range, bitespeed_bot, 'custom')
+  # end
+
+  private
+
+  def set_statement_timeout
+    ActiveRecord::Base.connection.execute("SET statement_timeout = '60s'")
+  end
+
+  def process_account(account_id, _current_date, range, bitespeed_bot, frequency = 'daily')
+    # pass individual label ids to the report builder and join them as one report
+    # get all the labels for the account
+    labels = Label.where(account_id: account_id)
+
+    Rails.logger.debug { "Labels: #{labels.inspect}" }
+
+    reports = []
+
+    labels.map do |label|
+      report = generate_inbox_report(account_id, range, label.title)
+      reports << report
+    end
+
+    if reports.present? && reports.length.positive?
+      Rails.logger.info "Data found for account_id: #{account_id}"
+
+      start_date = range[:since].strftime('%Y-%m-%d')
+      end_date = range[:until].strftime('%Y-%m-%d')
+
+      csv_content = generate_csv(reports, labels, start_date, end_date)
+      upload_csv(account_id, range, csv_content, frequency, bitespeed_bot)
+    else
+      Rails.logger.info "No data found for account_id: #{account_id}"
+    end
+  end
+
+  def generate_inbox_report(account_id, range, label)
+    account = Account.find(account_id)
+    account.inboxes.map do |inbox|
+      inbox_report = generate_report(account, { type: :inbox, id: inbox.id, since: range[:since], until: range[:until], label: label })
+      [inbox.name, inbox.channel&.name] + generate_readable_report_metrics(inbox_report)
+    end
+  end
+
+  def report_builder(account, report_params)
+    V2::ReportBuilder.new(
+      account,
+      report_params
+    )
+  end
+
+  def generate_report(account, report_params)
+    report_builder(account, report_params).short_summary
+  end
+
+  def generate_readable_report_metrics(report_metric)
+    [
+      report_metric[:conversations_count],
+      Reports::TimeFormatPresenter.new(report_metric[:avg_first_response_time]).format,
+      Reports::TimeFormatPresenter.new(report_metric[:avg_resolution_time]).format,
+      Reports::TimeFormatPresenter.new(report_metric[:online_time]).format,
+      Reports::TimeFormatPresenter.new(report_metric[:busy_time]).format,
+      Reports::TimeFormatPresenter.new(report_metric[:reply_time]).format,
+      report_metric[:resolutions_count]
+    ]
+  end
+
+  def generate_csv(results, labels, start_date, end_date)
+    Rails.logger.debug { "Results: #{results}" }
+    Rails.logger.debug { "Labels: #{labels}" }
+    Rails.logger.debug { "Start date: #{start_date}" }
+    Rails.logger.debug { "End date: #{end_date}" }
+    CSV.generate(headers: true) do |csv|
+      csv << ["Reporting period #{start_date} to #{end_date}"]
+      csv << []
+
+      labels.each_with_index do |label, index|
+        csv << ["Label: #{label.title}"]
+        csv << ['Inbox name', 'Inbox type', 'No. of conversations', 'Avg first response time', 'Avg resolution time']
+
+        results[index].each do |row|
+          csv << row
+        end
+
+        csv << []
+        csv << []
+      end
+    end
+  end
+
+  def upload_csv(account_id, range, csv_content, frequency, _bitespeed_bot)
+    start_date = range[:since].strftime('%Y-%m-%d')
+    end_date = range[:until].strftime('%Y-%m-%d')
+
+    # Determine the file name based on the frequency
+    file_name = "#{frequency}_conversation_report_#{account_id}_#{end_date}.csv"
+
+    # For testing locally, uncomment below
+    Rails.logger.debug csv_content
+    csv_url = file_name
+    File.write(csv_url, csv_content)
+
+    # Upload csv_content via ActiveStorage and print the URL
+    # blob = ActiveStorage::Blob.create_and_upload!(
+    #   io: StringIO.new(csv_content),
+    #   filename: file_name,
+    #   content_type: 'text/csv'
+    # )
+
+    # csv_url = Rails.application.routes.url_helpers.url_for(blob)
+
+    # Send email with the CSV URL
+    mailer = AdministratorNotifications::ChannelNotificationsMailer.with(account: Account.find(account_id))
+
+    if frequency == 'weekly'
+      mailer.weekly_conversation_report(csv_url, start_date, end_date).deliver_now
+    elsif frequency == 'daily'
+      mailer.daily_conversation_report(csv_url, end_date).deliver_now
+    end
+  end
+end

--- a/app/jobs/label_report_job.rb
+++ b/app/jobs/label_report_job.rb
@@ -1,0 +1,156 @@
+require 'json'
+require 'csv'
+
+class LabelReportJob < ApplicationJob
+  queue_as :scheduled_jobs
+
+  JOB_DATA_URL = 'https://bitespeed-app.s3.amazonaws.com/InternalAccess/cw-auto-conversation-report.json'.freeze
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/AbcSize
+  def perform
+    set_statement_timeout
+
+    response = HTTParty.get(JOB_DATA_URL)
+    job_data = JSON.parse(response.body, symbolize_names: true)
+
+    job_data = job_data[:label_report]
+
+    job_data.each do |job|
+      current_date = Date.current
+      current_day = current_date.wday
+
+      # should trigger only on 1st day of the month
+      next if job[:frequency] == 'monthly' && current_date.day != 1
+
+      # should trigger only on Mondays
+      next if job[:frequency] == 'weekly' && current_day != 1
+
+      range = if job[:frequency] == 'monthly'
+                { since: 1.month.ago.beginning_of_day, until: 1.day.ago.end_of_day }
+              elsif job[:frequency] == 'weekly'
+                { since: 1.week.ago.beginning_of_day, until: 1.day.ago.end_of_day }
+              else
+                { since: 1.day.ago.beginning_of_day, until: 1.day.ago.end_of_day }
+              end
+
+      process_account(job[:account_id], range, false, job[:frequency])
+    end
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/AbcSize
+
+  def set_statement_timeout
+    ActiveRecord::Base.connection.execute("SET statement_timeout = '60s'")
+  end
+
+  def process_account(account_id, range, bitespeed_bot, frequency = 'daily')
+    agents = AccountUser.where(account_id: account_id)
+    agent_users = User.where(id: agents.pluck(:user_id))
+    reports = []
+
+    agents.each do |agent|
+      report = generate_label_report_per_agent(account_id, range, agent)
+      reports << report
+    end
+
+    if reports.present? && reports.length.positive?
+      Rails.logger.info "Data found for account_id: #{account_id}"
+
+      start_date = range[:since].strftime('%Y-%m-%d')
+      end_date = range[:until].strftime('%Y-%m-%d')
+
+      csv_content = generate_csv(reports, agent_users, start_date, end_date)
+      upload_csv(account_id, range, csv_content, frequency, bitespeed_bot)
+    else
+      Rails.logger.info "No data found for account_id: #{account_id}"
+    end
+  end
+
+  def generate_label_report_per_agent(account_id, range, agent)
+    account = Account.find(account_id)
+    account.labels.map do |label|
+      report = generate_report(account, { type: :label, id: label.id, since: range[:since], until: range[:until], assignee_id: agent.user_id })
+      [label.title] + generate_readable_report_metrics(report)
+    end
+  end
+
+  def report_builder(account, report_params)
+    V2::ReportBuilder.new(
+      account,
+      report_params
+    )
+  end
+
+  def generate_report(account, report_params)
+    report_builder(account, report_params).custom_short_summary
+  end
+
+  def generate_readable_report_metrics(report)
+    [
+      report[:conversations_count],
+      Reports::TimeFormatPresenter.new(report[:avg_first_response_time]).format,
+      Reports::TimeFormatPresenter.new(report[:avg_resolution_time]).format,
+      report[:open_conversations_count],
+      report[:unattended_conversations_count],
+      report[:resolved_conversations_count]
+    ]
+  end
+
+  def generate_csv(results, agent_users, start_date, end_date)
+    CSV.generate(headers: true) do |csv|
+      csv << ["Reporting period #{start_date} to #{end_date}"]
+      csv << []
+
+      agent_users.each_with_index do |agent_user, index|
+        csv << ["Agent Name: #{agent_user.name}"]
+        csv << ['Label', 'No. of conversations', 'Avg first response time', 'Avg resolution time', 'Open conversations', 'Unattended conversations',
+                'Resolved conversations']
+
+        results[index].each do |row|
+          csv << row
+        end
+
+        csv << []
+        csv << []
+      end
+    end
+  end
+
+  def upload_csv(account_id, range, csv_content, frequency, _bitespeed_bot)
+    start_date = range[:since].strftime('%Y-%m-%d')
+    end_date = range[:until].strftime('%Y-%m-%d')
+
+    # Determine the file name based on the frequency
+    file_name = "#{frequency}_conversation_report_#{account_id}_#{end_date}.csv"
+
+    # For testing locally, uncomment below
+    # Rails.logger.debug csv_content
+    # csv_url = file_name
+    # File.write(csv_url, csv_content)
+    # Rails.logger.debug "CSV URL: #{csv_url}"
+
+    # Upload csv_content via ActiveStorage and print the URL
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(csv_content),
+      filename: file_name,
+      content_type: 'text/csv'
+    )
+
+    csv_url = Rails.application.routes.url_helpers.url_for(blob)
+
+    # Send email with the CSV URL
+    mailer = AdministratorNotifications::ChannelNotificationsMailer.with(account: Account.find(account_id))
+
+    case frequency
+    when 'monthly'
+      mailer.monthly_label_report(csv_url, start_date, end_date).deliver_now
+    when 'weekly'
+      mailer.weekly_label_report(csv_url, start_date, end_date).deliver_now
+    when 'daily'
+      mailer.daily_label_report(csv_url, end_date).deliver_now
+    end
+  end
+end

--- a/app/mailers/administrator_notifications/channel_notifications_mailer.rb
+++ b/app/mailers/administrator_notifications/channel_notifications_mailer.rb
@@ -77,6 +77,30 @@ class AdministratorNotifications::ChannelNotificationsMailer < ApplicationMailer
     send_mail_with_liquid(to: recipients, subject: subject) and return
   end
 
+  def daily_agent_report(csv_url, current_date)
+    return unless smtp_config_set_or_development?
+
+    subject = "Daily Agent Report for #{current_date}"
+    @action_url = csv_url
+    send_mail_with_liquid(to: admin_emails + ['jaideep+chatwootreports@bitespeed.co', 'aryanm@bitespeed.co'], subject: subject) and return
+  end
+
+  def weekly_agent_report(csv_url, since_date, until_date)
+    return unless smtp_config_set_or_development?
+
+    subject = "Weekly Agent Report from #{since_date} to #{until_date}"
+    @action_url = csv_url
+    send_mail_with_liquid(to: admin_emails + ['jaideep+chatwootreports@bitespeed.co', 'aryanm@bitespeed.co'], subject: subject) and return
+  end
+
+  def monthly_agent_report(csv_url, since_date, until_date)
+    return unless smtp_config_set_or_development?
+
+    subject = "Monthly Agent Report from #{since_date} to #{until_date}"
+    @action_url = csv_url
+    send_mail_with_liquid(to: admin_emails + ['jaideep+chatwootreports@bitespeed.co', 'aryanm@bitespeed.co'], subject: subject) and return
+  end
+
   def custom_agent_report(csv_url, since_date, until_date, bitespeed_bot)
     return unless smtp_config_set_or_development?
 
@@ -85,6 +109,30 @@ class AdministratorNotifications::ChannelNotificationsMailer < ApplicationMailer
     recipients = admin_emails
     recipients += ['jaideep+chatwootdebugreports@bitespeed.co', 'aryanm@bitespeed.co', 'vinayaktrivedi@bitespeed.co'] if bitespeed_bot
     send_mail_with_liquid(to: recipients, subject: subject) and return
+  end
+
+  def daily_label_report(csv_url, current_date)
+    return unless smtp_config_set_or_development?
+
+    subject = "Daily Label Report for #{current_date}"
+    @action_url = csv_url
+    send_mail_with_liquid(to: admin_emails + ['jaideep+chatwootreports@bitespeed.co', 'aryanm@bitespeed.co'], subject: subject) and return
+  end
+
+  def weekly_label_report(csv_url, since_date, until_date)
+    return unless smtp_config_set_or_development?
+
+    subject = "Weekly Label Report from #{since_date} to #{until_date}"
+    @action_url = csv_url
+    send_mail_with_liquid(to: admin_emails + ['jaideep+chatwootreports@bitespeed.co', 'aryanm@bitespeed.co'], subject: subject) and return
+  end
+
+  def monthly_label_report(csv_url, since_date, until_date)
+    return unless smtp_config_set_or_development?
+
+    subject = "Monthly Label Report from #{since_date} to #{until_date}"
+    @action_url = csv_url
+    send_mail_with_liquid(to: admin_emails + ['jaideep+chatwootreports@bitespeed.co', 'aryanm@bitespeed.co'], subject: subject) and return
   end
 
   def contact_import_failed

--- a/app/views/mailers/administrator_notifications/channel_notifications_mailer/daily_agent_report.liquid
+++ b/app/views/mailers/administrator_notifications/channel_notifications_mailer/daily_agent_report.liquid
@@ -1,0 +1,9 @@
+<p>Hello,</p>
+
+<p>Here is the daily agent report.</p>
+
+<p>
+Click <a href="{{action_url}}">here</a> to download.
+</p>
+
+<p>Regards,<br>BiteSpeed</p>

--- a/app/views/mailers/administrator_notifications/channel_notifications_mailer/daily_label_report.liquid
+++ b/app/views/mailers/administrator_notifications/channel_notifications_mailer/daily_label_report.liquid
@@ -1,0 +1,9 @@
+<p>Hello,</p>
+
+<p>Here is the daily label report.</p>
+
+<p>
+Click <a href="{{action_url}}">here</a> to download.
+</p>
+
+<p>Regards,<br>BiteSpeed</p>

--- a/app/views/mailers/administrator_notifications/channel_notifications_mailer/monthly_agent_report.liquid
+++ b/app/views/mailers/administrator_notifications/channel_notifications_mailer/monthly_agent_report.liquid
@@ -1,0 +1,9 @@
+<p>Hello,</p>
+
+<p>Here is the monthly agent report.</p>
+
+<p>
+Click <a href="{{action_url}}">here</a> to download.
+</p>
+
+<p>Regards,<br>BiteSpeed</p>

--- a/app/views/mailers/administrator_notifications/channel_notifications_mailer/monthly_label_report.liquid
+++ b/app/views/mailers/administrator_notifications/channel_notifications_mailer/monthly_label_report.liquid
@@ -1,0 +1,9 @@
+<p>Hello,</p>
+
+<p>Here is the monthly label report.</p>
+
+<p>
+Click <a href="{{action_url}}">here</a> to download.
+</p>
+
+<p>Regards,<br>BiteSpeed</p>

--- a/app/views/mailers/administrator_notifications/channel_notifications_mailer/weekly_agent_report.liquid
+++ b/app/views/mailers/administrator_notifications/channel_notifications_mailer/weekly_agent_report.liquid
@@ -1,0 +1,9 @@
+<p>Hello,</p>
+
+<p>Here is the weekly agent report.</p>
+
+<p>
+Click <a href="{{action_url}}">here</a> to download.
+</p>
+
+<p>Regards,<br>BiteSpeed</p>

--- a/app/views/mailers/administrator_notifications/channel_notifications_mailer/weekly_label_report.liquid
+++ b/app/views/mailers/administrator_notifications/channel_notifications_mailer/weekly_label_report.liquid
@@ -1,0 +1,9 @@
+<p>Hello,</p>
+
+<p>Here is the weekly label report.</p>
+
+<p>
+Click <a href="{{action_url}}">here</a> to download.
+</p>
+
+<p>Regards,<br>BiteSpeed</p>

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -37,3 +37,13 @@ daily_conversation_report_job:
   cron: '30 3 * * *'
   class: 'DailyConversationReportJob'
   queue: scheduled_jobs
+
+label_report_job:
+  cron: '30 3 * * *'
+  class: 'LabelReportJob'
+  queue: scheduled_jobs
+
+agent_report_job:
+  cron: '30 3 * * *'
+  class: 'AgentReportJob'
+  queue: scheduled_jobs


### PR DESCRIPTION
## What

- Added metrics for conversations count, incoming messages count, outgoing messages count, average first response time, average resolution time, open conversations count, unattended conversations count, resolutions count, reply time, online time, and busy time in the `custom_summary` method.
- Updated the `short_summary` method to include open conversations count, resolutions count, and removed unnecessary metrics.
- Enhanced the `live_conversations` method to handle different filtering scenarios based on parameters.
- Modified the `avg_first_response_time_summary` and `avg_resolution_time_summary` methods to handle scenarios with or without an assignee ID parameter.
- Introduced logic to handle different frequencies in the `AgentReportJob`.
- Implemented methods to generate custom reports and upload them based on the frequency in the `LabelReportJob`.
- Developed logic to fetch and process data for daily agent reports in the `DailyAgentReportJob`.
- Implemented email templates for daily, weekly, and monthly agent reports as well as labels in the `ChannelNotificationsMailer`.
- Added view templates for daily, weekly, and monthly agent reports as well as labels in the mailer directory.
