### PR TITLE
feat: support to header, footer in wa template

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -168,6 +168,12 @@ class Messages::MessageBuilder
     @params[:template_params].present? ? { additional_attributes: { template_params: JSON.parse(@params[:template_params].to_json) } } : {}
   end
 
+  def template_params_stringified
+    # rubocop:disable Layout/LineLength
+    @params[:stringified_template_params].present? ? { additional_attributes: { template_params: JSON.parse(@params[:stringified_template_params]) } } : {}
+    # rubocop:enable Layout/LineLength
+  end
+
   def ignore_automation_rules
     @ignore_automation_rules.present? && @ignore_automation_rules == 'true' ? { additional_attributes: { ignore_automation_rules: true } } : {}
   end
@@ -196,7 +202,7 @@ class Messages::MessageBuilder
       in_reply_to: @in_reply_to,
       echo_id: @params[:echo_id],
       source_id: @params[:source_id]
-    }.merge(external_created_at).merge(automation_rule_id).merge(campaign_id).merge(template_params).merge(ignore_automation_rules).merge(disable_notifications)
+    }.merge(external_created_at).merge(automation_rule_id).merge(campaign_id).merge(template_params).merge(ignore_automation_rules).merge(disable_notifications).merge(template_params_stringified)
   end
   # rubocop:enable Layout/LineLength
 end

--- a/app/javascript/dashboard/api/inbox/message.js
+++ b/app/javascript/dashboard/api/inbox/message.js
@@ -23,6 +23,12 @@ export const buildCreatePayload = ({
       payload.append('attachments[]', file);
     });
     payload.append('private', isPrivate);
+    if (templateParams) {
+      payload.append(
+        'stringified_template_params',
+        JSON.stringify(templateParams)
+      );
+    }
     payload.append('echo_id', echoId);
     payload.append('cc_emails', ccEmails);
     payload.append('bcc_emails', bccEmails);

--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
@@ -252,6 +252,7 @@ export default {
         try {
           const { fileUrl, blobId } = await uploadFile(file.file);
           this.uploadedFile = {
+            file: file.file,
             name: file.name,
             url: fileUrl,
             blobId: blobId,
@@ -284,11 +285,15 @@ export default {
           processed_params: this.processedParams,
         },
       };
-      // If there's a file upload for the header, you might want to handle it separately
+
       if (this.uploadedFile) {
-        payload.attachments = [this.uploadedFile.blobId];
+        if (this.globalConfig.directUploadsEnabled) {
+          payload.files = [this.uploadedFile.blobId];
+        } else {
+          payload.files = [this.uploadedFile.file];
+        }
       }
-      this.$emit('sendMessage', payload);
+      this.$emit('createPendingMessageAndSend', payload);
     },
     processVariable(str) {
       return str.replace(/{{|}}/g, '');

--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
@@ -285,15 +285,10 @@ export default {
           processed_params: this.processedParams,
         },
       };
-
       if (this.uploadedFile) {
-        if (this.globalConfig.directUploadsEnabled) {
-          payload.files = [this.uploadedFile.blobId];
-        } else {
-          payload.files = [this.uploadedFile.file];
-        }
+        payload.files = [this.uploadedFile.file];
       }
-      this.$emit('createPendingMessageAndSend', payload);
+      this.$emit('sendMessage', payload);
     },
     processVariable(str) {
       return str.replace(/{{|}}/g, '');

--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
@@ -1,52 +1,89 @@
 <template>
   <div class="w-full">
-    <textarea
-      v-model="processedString"
-      rows="4"
-      readonly
-      class="template-input"
-    />
-    <div v-if="variables" class="template__variables-container">
-      <p class="variables-label">
-        {{ $t('WHATSAPP_TEMPLATES.PARSER.VARIABLES_LABEL') }}
-      </p>
+    <div class="max-h-[22.75rem] overflow-y-auto">
       <div
-        v-for="(variable, key) in processedParams"
-        :key="key"
-        class="template__variable-item"
+        v-for="(componentVariables, componentType) in variables"
+        :key="componentType"
       >
-        <span class="variable-label">
-          {{ key }}
-        </span>
-        <woot-input
-          v-model="processedParams[key]"
-          type="text"
-          class="variable-input"
-          :styles="{ marginBottom: 0 }"
+        <h3>
+          {{ `${componentType.toUpperCase()}` }}
+        </h3>
+        <textarea
+          v-if="processedString[componentType]"
+          v-model="processedString[componentType]"
+          rows="4"
+          readonly
+          class="template-input"
         />
+        <div
+          v-if="
+            componentVariables.length ||
+            (componentType === 'header' && isHeaderMediaFormat)
+          "
+          class="template__variables-container"
+        >
+          <p class="variables-label">
+            {{ `${getHeaderMediaFormat}` }}
+          </p>
+          <!-- Add file upload option for header with specific formats -->
+          <template v-if="componentType === 'header' && isHeaderMediaFormat">
+            <file-upload
+              :accept="acceptedFileTypes"
+              :size="MAXIMUM_FILE_UPLOAD_SIZE * 1024 * 1024"
+              @input-file="handleFileUpload"
+            >
+              <woot-button variant="smooth">
+                {{ `Upload ${getHeaderMediaFormat}` }}
+              </woot-button>
+            </file-upload>
+            <p v-if="uploadedFile">
+              {{ uploadedFile.name }}
+            </p>
+          </template>
+          <div
+            v-for="variable in componentVariables"
+            :key="`${componentType}-${variable}`"
+            class="template__variable-item"
+          >
+            <span class="variable-label">
+              {{ processVariable(variable) }}
+            </span>
+            <woot-input
+              v-model="
+                processedParams[componentType][processVariable(variable)]
+              "
+              type="text"
+              class="variable-input"
+              :styles="{ marginBottom: 0 }"
+            />
+          </div>
+        </div>
       </div>
       <p v-if="$v.$dirty && $v.$invalid" class="error">
         {{ $t('WHATSAPP_TEMPLATES.PARSER.FORM_ERROR_MESSAGE') }}
       </p>
+      <footer>
+        <woot-button variant="smooth" @click="$emit('resetTemplate')">
+          {{ $t('WHATSAPP_TEMPLATES.PARSER.GO_BACK_LABEL') }}
+        </woot-button>
+        <woot-button type="button" @click="sendMessage">
+          {{ $t('WHATSAPP_TEMPLATES.PARSER.SEND_MESSAGE_LABEL') }}
+        </woot-button>
+      </footer>
     </div>
-    <footer>
-      <woot-button variant="smooth" @click="$emit('resetTemplate')">
-        {{ $t('WHATSAPP_TEMPLATES.PARSER.GO_BACK_LABEL') }}
-      </woot-button>
-      <woot-button type="button" @click="sendMessage">
-        {{ $t('WHATSAPP_TEMPLATES.PARSER.SEND_MESSAGE_LABEL') }}
-      </woot-button>
-    </footer>
   </div>
 </template>
-
 <script>
-const allKeysRequired = value => {
-  const keys = Object.keys(value);
-  return keys.every(key => value[key]);
-};
 import { requiredIf } from 'vuelidate/lib/validators';
+import FileUpload from 'vue-upload-component';
+import { checkFileSizeLimit } from 'shared/helpers/FileHelper';
+import { MAXIMUM_FILE_UPLOAD_SIZE } from 'shared/constants/messages';
+import { uploadFile } from 'dashboard/helper/uploadHelper';
+
 export default {
+  components: {
+    FileUpload,
+  },
   props: {
     template: {
       type: Object,
@@ -55,41 +92,190 @@ export default {
   },
   validations: {
     processedParams: {
-      requiredIfKeysPresent: requiredIf('variables'),
-      allKeysRequired,
+      header: {
+        $each: {
+          $required: requiredIf(function (value, key) {
+            return (
+              this.variables.header &&
+              this.variables.header.includes(`{{${key}}}`)
+            );
+          }),
+        },
+      },
+      body: {
+        $each: {
+          $required: requiredIf(function (value, key) {
+            return (
+              this.variables.body && this.variables.body.includes(`{{${key}}}`)
+            );
+          }),
+        },
+      },
+      footer: {
+        $each: {
+          $required: requiredIf(function (value, key) {
+            return (
+              this.variables.footer &&
+              this.variables.footer.includes(`{{${key}}}`)
+            );
+          }),
+        },
+      },
     },
   },
   data() {
     return {
-      processedParams: {},
+      processedParams: {
+        header: {},
+        body: {},
+        footer: {},
+      },
+      uploadedFile: null,
     };
   },
   computed: {
     variables() {
-      const variables = this.templateString.match(/{{([^}]+)}}/g);
-      return variables;
-    },
-    templateString() {
-      return this.template.components.find(
-        component => component.type === 'BODY'
-      ).text;
+      const allVariables = {};
+      ['header', 'body', 'footer'].forEach(componentType => {
+        const component = this.template.components.find(
+          c => c.type === componentType.toUpperCase()
+        );
+        if (component) {
+          allVariables[componentType] = this.extractVariables(component);
+        }
+      });
+      return allVariables;
     },
     processedString() {
-      return this.templateString.replace(/{{([^}]+)}}/g, (match, variable) => {
-        const variableKey = this.processVariable(variable);
-        return this.processedParams[variableKey] || `{{${variable}}}`;
+      const processed = {};
+      ['header', 'body', 'footer'].forEach(componentType => {
+        const component = this.template.components.find(
+          c => c.type === componentType.toUpperCase()
+        );
+        if (component) {
+          processed[componentType] = this.replaceVariables(
+            component,
+            componentType
+          );
+        }
       });
+      return processed;
+    },
+    processedContentString() {
+      let content = this.processedString.body;
+      if (this.processedString.footer) {
+        content += `\n\n${this.processedString.footer}`;
+      }
+      if (
+        !['IMAGE', 'VIDEO', 'DOCUMENT'].includes(
+          this.template.components.find(c => c.type === 'HEADER').format
+        )
+      ) {
+        content = `${this.processedString.header}\n\n${content}`;
+      }
+      return content;
+    },
+    getHeaderMediaFormat() {
+      const headerComponent = this.template.components.find(
+        c => c.type === 'HEADER'
+      );
+      return (
+        headerComponent?.format
+          ?.toLowerCase()
+          .replace(/^./, c => c.toUpperCase()) || ''
+      );
+    },
+    isHeaderMediaFormat() {
+      const headerComponent = this.template.components.find(
+        c => c.type === 'HEADER'
+      );
+      return (
+        headerComponent &&
+        ['IMAGE', 'VIDEO', 'DOCUMENT'].includes(headerComponent.format)
+      );
+    },
+    acceptedFileTypes() {
+      const headerComponent = this.template.components.find(
+        c => c.type === 'HEADER'
+      );
+      switch (headerComponent?.format) {
+        case 'IMAGE':
+          return 'image/*';
+        case 'VIDEO':
+          return 'video/*';
+        case 'DOCUMENT':
+          return '.pdf,.doc,.docx,.xls,.xlsx';
+        default:
+          return '';
+      }
     },
   },
   mounted() {
     this.generateVariables();
   },
   methods: {
+    extractVariables(component) {
+      if (!component || !component.text) return [];
+      return component.text.match(/{{([^}]+)}}/g) || [];
+    },
+    replaceVariables(component, componentType) {
+      if (!component || !component.text) return '';
+      return component.text.replace(/{{([^}]+)}}/g, (match, variable) => {
+        const variableKey = this.processVariable(variable);
+        return (
+          this.processedParams[componentType][variableKey] || `{{${variable}}}`
+        );
+      });
+    },
+    generateVariables() {
+      ['header', 'body', 'footer'].forEach(componentType => {
+        const component = this.template.components.find(
+          c => c.type === componentType.toUpperCase()
+        );
+        if (component) {
+          const variables = this.extractVariables(component);
+          this.processedParams[componentType] = variables.reduce(
+            (acc, variable) => {
+              const key = this.processVariable(variable);
+              acc[key] = '';
+              return acc;
+            },
+            {}
+          );
+        }
+      });
+    },
+    async handleFileUpload(file) {
+      if (!file) return;
+
+      if (checkFileSizeLimit(file, MAXIMUM_FILE_UPLOAD_SIZE)) {
+        try {
+          const { fileUrl, blobId } = await uploadFile(file.file);
+          this.uploadedFile = {
+            name: file.name,
+            url: fileUrl,
+            blobId: blobId,
+          };
+          this.processedParams.header[this.processVariable('{{header}}')] =
+            fileUrl;
+        } catch (error) {
+          // Handle error
+          // console.error('Error uploading file:', error);
+        }
+      } else {
+        // Show error message for file size limit
+        this.$emit('show-alert', {
+          message: this.$t('CONVERSATION.FILE_SIZE_LIMIT', {
+            MAXIMUM_FILE_UPLOAD_SIZE,
+          }),
+        });
+      }
+    },
     sendMessage() {
       this.$v.$touch();
       if (this.$v.$invalid) return;
       const payload = {
-        message: this.processedString,
+        message: this.processedContentString,
         templateParams: {
           name: this.template.name,
           category: this.template.category,
@@ -98,20 +284,14 @@ export default {
           processed_params: this.processedParams,
         },
       };
+      // If there's a file upload for the header, you might want to handle it separately
+      if (this.uploadedFile) {
+        payload.attachments = [this.uploadedFile.blobId];
+      }
       this.$emit('sendMessage', payload);
     },
     processVariable(str) {
       return str.replace(/{{|}}/g, '');
-    },
-    generateVariables() {
-      const matchedVariables = this.templateString.match(/{{([^}]+)}}/g);
-      if (!matchedVariables) return;
-
-      const variables = matchedVariables.map(i => this.processVariable(i));
-      this.processedParams = variables.reduce((acc, variable) => {
-        acc[variable] = '';
-        return acc;
-      }, {});
     },
   },
 };
@@ -133,7 +313,8 @@ export default {
     @apply text-xs;
   }
 
-  .variable-input {
+  .variable-input,
+  input[type='file'] {
     @apply flex-1 text-sm ml-2.5;
   }
 

--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
@@ -284,6 +284,7 @@ export default {
           namespace: this.template.namespace,
           processed_params: this.processedParams,
         },
+        private: false,
       };
       if (this.uploadedFile) {
         payload.files = [this.uploadedFile.file];

--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
@@ -256,8 +256,8 @@ export default {
             url: fileUrl,
             blobId: blobId,
           };
-          this.processedParams.header[this.processVariable('{{header}}')] =
-            fileUrl;
+
+          this.processedParams.header[this.processVariable('{{1}}')] = fileUrl;
         } catch (error) {
           // Handle error
           // console.error('Error uploading file:', error);

--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplatesPicker.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplatesPicker.vue
@@ -34,6 +34,14 @@
               </p>
               <p class="label-body">{{ getTemplatebody(template) }}</p>
             </div>
+            <div v-if="getTemplateHeader(template)">
+              <p class="strong">Template Header</p>
+              <p class="label-body">{{ getTemplateHeader(template) }}</p>
+            </div>
+            <div v-if="getTemplateFooter(template)">
+              <p class="strong">Template Footer</p>
+              <p class="label-body">{{ getTemplateFooter(template) }}</p>
+            </div>
             <div class="label-category">
               <p class="strong">
                 {{ $t('WHATSAPP_TEMPLATES.PICKER.LABELS.CATEGORY') }}
@@ -55,9 +63,6 @@
 </template>
 
 <script>
-// TODO: Remove this when we support all formats
-const formatsToRemove = ['DOCUMENT', 'IMAGE', 'VIDEO'];
-
 export default {
   props: {
     inboxId: {
@@ -72,14 +77,12 @@ export default {
   },
   computed: {
     whatsAppTemplateMessages() {
-      // TODO: Remove the last filter when we support all formats
       return this.$store.getters['inboxes/getWhatsAppTemplates'](this.inboxId)
         .filter(template => template.status.toLowerCase() === 'approved')
-        .filter(template => {
-          return template.components.every(component => {
-            return !formatsToRemove.includes(component.format);
-          });
-        });
+        .filter(
+          template =>
+            !template.components.some(component => component.type === 'BUTTONS')
+        );
     },
     filteredTemplateMessages() {
       return this.whatsAppTemplateMessages.filter(template =>
@@ -91,6 +94,20 @@ export default {
     getTemplatebody(template) {
       return template.components.find(component => component.type === 'BODY')
         .text;
+    },
+    getTemplateHeader(template) {
+      const headerComponent = template.components.find(
+        component => component.type === 'HEADER'
+      );
+      return headerComponent
+        ? headerComponent.text || headerComponent.format
+        : null;
+    },
+    getTemplateFooter(template) {
+      const footerComponent = template.components.find(
+        component => component.type === 'FOOTER'
+      );
+      return footerComponent ? footerComponent.text : null;
     },
   },
 };

--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -64,12 +64,10 @@ export const getters = {
     const messagesTemplates =
       whatsAppMessageTemplates || apiInboxMessageTemplates;
 
-    // filtering out the whatsapp templates with media
+    // filtering out the whatsapp templates with buttons
     if (messagesTemplates instanceof Array) {
       return messagesTemplates.filter(template => {
-        return !template.components.some(
-          i => i.format === 'IMAGE' || i.format === 'VIDEO'
-        );
+        return !template.components.some(i => i.type === 'BUTTONS');
       });
     }
     return [];


### PR DESCRIPTION
## What

Enhance the TemplateParser component to support uploading specific file types for the header section in WhatsApp templates. This change includes:
- Updating the component to handle header media formats like images, videos, and documents.
- Introducing a file upload option for header components with specific formats.
- Enhancing the user interface to allow file uploads for header sections.
- Modifying the component logic to process and display uploaded files in the header.
- Including validation for file size limits during uploads.
