### PR TITLE
fix: agent report and label report in business hours

### DIFF
--- a/app/jobs/agent_report_job.rb
+++ b/app/jobs/agent_report_job.rb
@@ -15,7 +15,7 @@ class AgentReportJob < ApplicationJob
     response = HTTParty.get(JOB_DATA_URL)
     job_data = JSON.parse(response.body, symbolize_names: true)
 
-    job_data = job_data['agent_report']
+    job_data = job_data[:agent_report]
 
     job_data.each do |job|
       current_date = Date.current
@@ -35,7 +35,9 @@ class AgentReportJob < ApplicationJob
                 { since: 1.day.ago.beginning_of_day, until: 1.day.ago.end_of_day }
               end
 
-      process_account(Account.find(job[:account_id]), range, range, false, job[:frequency])
+      params = range.merge({ business_hours: true })
+
+      process_account(Account.find(job[:account_id]), range, params, false, job[:frequency])
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity
@@ -49,7 +51,7 @@ class AgentReportJob < ApplicationJob
   end
 
   def set_statement_timeout
-    ActiveRecord::Base.connection.execute("SET statement_timeout = '120s'")
+    ActiveRecord::Base.connection.execute("SET statement_timeout = '180s'")
   end
 
   def report_builder(account, report_params)

--- a/app/jobs/label_report_job.rb
+++ b/app/jobs/label_report_job.rb
@@ -72,7 +72,9 @@ class LabelReportJob < ApplicationJob
   def generate_label_report_per_agent(account_id, range, agent)
     account = Account.find(account_id)
     account.labels.map do |label|
-      report = generate_report(account, { type: :label, id: label.id, since: range[:since], until: range[:until], assignee_id: agent.user_id })
+      report = generate_report(account,
+                               { type: :label, id: label.id, since: range[:since], until: range[:until], assignee_id: agent.user_id,
+                                 business_hours: true })
       [label.title] + generate_readable_report_metrics(report)
     end
   end
@@ -124,7 +126,7 @@ class LabelReportJob < ApplicationJob
     end_date = range[:until].strftime('%Y-%m-%d')
 
     # Determine the file name based on the frequency
-    file_name = "#{frequency}_conversation_report_#{account_id}_#{end_date}.csv"
+    file_name = "#{frequency}_label_report_#{account_id}_#{end_date}.csv"
 
     # For testing locally, uncomment below
     # Rails.logger.debug csv_content


### PR DESCRIPTION
## What
Enhance the `agent_report` and `label_report` jobs to incorporate a parameter for business hours. Adjust the data processing logic to include `business_hours: true` in report generation, providing a clearer context for the reports produced.