### PR TITLE
feat: added a button in superadmin view to clear cache & improved logic to prevent accidental access blocks

### DIFF
--- a/app/controllers/super_admin/accounts_controller.rb
+++ b/app/controllers/super_admin/accounts_controller.rb
@@ -33,6 +33,8 @@ class SuperAdmin::AccountsController < SuperAdmin::ApplicationController
   # empty values into nil values. It uses other APIs such as `resource_class`
   # and `dashboard`:
   #
+  include BspdAccessHelper
+
   def resource_params
     permitted_params = super
     permitted_params[:limits] = permitted_params[:limits].to_h.compact
@@ -54,6 +56,13 @@ class SuperAdmin::AccountsController < SuperAdmin::ApplicationController
     requested_resource.reset_cache_keys
     # rubocop:disable Rails/I18nLocaleTexts
     redirect_back(fallback_location: [namespace, requested_resource], notice: 'Cache keys cleared')
+    # rubocop:enable Rails/I18nLocaleTexts
+  end
+
+  def clear_billing_cache
+    clear_cache(requested_resource.id)
+    # rubocop:disable Rails/I18nLocaleTexts
+    redirect_back(fallback_location: [namespace, requested_resource], notice: 'Billing cache cleared')
     # rubocop:enable Rails/I18nLocaleTexts
   end
 

--- a/app/helpers/bspd_access_helper.rb
+++ b/app/helpers/bspd_access_helper.rb
@@ -17,9 +17,13 @@ module BspdAccessHelper
       response = HTTParty.get("https://ufg5p259v2.execute-api.us-east-1.amazonaws.com/prod/csdb/auth/verify?accountId=#{active_account_id}")
       Rails.logger.info "BSPD Access Helper: Billing status response - #{response}"
 
-      result = response.success? && response.code != 500
+      if [200, 400, 403].include?(response.code)
+        result = response.success?
 
-      Redis::Alfred.setex(cache_key, result.to_s, CACHE_TTL) unless response.code == 500
+        Redis::Alfred.setex(cache_key, result.to_s, CACHE_TTL)
+      else
+        result = true
+      end
     rescue StandardError => e
       Rails.logger.error "BSPD Access Helper: Error checking billing status - #{e.message}"
       result = false

--- a/app/helpers/bspd_access_helper.rb
+++ b/app/helpers/bspd_access_helper.rb
@@ -17,13 +17,14 @@ module BspdAccessHelper
       response = HTTParty.get("https://ufg5p259v2.execute-api.us-east-1.amazonaws.com/prod/csdb/auth/verify?accountId=#{active_account_id}")
       Rails.logger.info "BSPD Access Helper: Billing status response - #{response}"
 
-      result = response.success?
+      result = response.success? && response.code != 500
+
+      Redis::Alfred.setex(cache_key, result.to_s, CACHE_TTL) unless response.code == 500
     rescue StandardError => e
       Rails.logger.error "BSPD Access Helper: Error checking billing status - #{e.message}"
       result = false
     end
 
-    Redis::Alfred.setex(cache_key, result.to_s, CACHE_TTL)
     result
   end
 

--- a/app/views/super_admin/accounts/_reset_billing_cache.html.erb
+++ b/app/views/super_admin/accounts/_reset_billing_cache.html.erb
@@ -2,8 +2,8 @@
  <hr/>
   <%= form_for([:clear_billing_cache, namespace, page.resource], method: :post, html: { class: "form" }) do |f| %>
     <div class="form-actions">
-      <%= f.submit 'Reset Billing Status' %>
       <p>This will clear the billing status cache. The next load will fetch the data from BSPD.</p>
+      <%= f.submit 'Reset Billing Status' %>
     </div>
   <% end %>
 </section>

--- a/app/views/super_admin/accounts/_reset_billing_cache.html.erb
+++ b/app/views/super_admin/accounts/_reset_billing_cache.html.erb
@@ -1,0 +1,9 @@
+<section class="main-content__body">
+ <hr/>
+  <%= form_for([:clear_billing_cache, namespace, page.resource], method: :post, html: { class: "form" }) do |f| %>
+    <div class="form-actions">
+      <%= f.submit 'Reset Billing Status' %>
+      <p>This will clear the billing status cache. The next load will fetch the data from BSPD.</p>
+    </div>
+  <% end %>
+</section>

--- a/app/views/super_admin/accounts/show.html.erb
+++ b/app/views/super_admin/accounts/show.html.erb
@@ -96,6 +96,8 @@ as well as a link to its edit page.
 
 </section>
 
+<%= render partial: "reset_billing_cache", locals: {page: page} %>
+
 <%= render partial: "seed_data", locals: {page: page} %>
 
 <%= render partial: "reset_cache", locals: {page: page} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -485,6 +485,7 @@ Rails.application.routes.draw do
       resources :accounts, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
         post :seed, on: :member
         post :reset_cache, on: :member
+        post :clear_billing_cache, on: :member
       end
       resources :users, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
         delete :avatar, on: :member, action: :destroy_avatar


### PR DESCRIPTION
## What

Introduce a new feature that allows superadmins to reset the billing status cache directly from the account page. Implement a dedicated form that, when submitted, clears the billing cache and provides user feedback upon successful execution. Update the helper logic to ensure better error handling and caching conditions for billing status checks.

## Why

Add a button in the superadmin view to clear the billing cache, enhancing the user interface and improving operational efficiency. This change addresses the need for easier cache management and aligns with internal requirements for better access control.

### Button
![image](https://github.com/user-attachments/assets/1d69d32f-050f-4285-a7e3-42436ede300c)