### PR TITLE
feat: button to assign all unassigned conversations to online agents

### DIFF
--- a/app/builders/unassigned_conversations_assignment_job.rb
+++ b/app/builders/unassigned_conversations_assignment_job.rb
@@ -1,0 +1,23 @@
+class UnassignedConversationsAssignmentJob < ApplicationJob
+  queue_as :critical
+
+  def perform(inbox_id)
+    cache_key = "unassigned_conversations_assignment_job_status_#{inbox_id}"
+
+    cache_value = Rails.cache.read(cache_key)
+
+    return if cache_value == 'running'
+
+    Rails.cache.write(cache_key, 'running')
+
+    inbox = Inbox.find(inbox_id)
+
+    unassigned_conversations = inbox.conversations.unassigned
+
+    unassigned_conversations.each do |conversation|
+      ::AutoAssignment::AgentAssignmentService.new(conversation: conversation, allowed_agent_ids: inbox.member_ids_with_assignment_capacity).perform
+    end
+
+    Rails.cache.delete(cache_key)
+  end
+end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -61,7 +61,20 @@ class Api::V1::AccountsController < Api::BaseController
     clear_cache(params[:id])
     head :ok
   end
-  
+
+  def unassigned_conversations_assignment
+    inbox_ids = params[:inbox_ids]
+    begin
+      inbox_ids.each do |inbox_id|
+        UnassignedConversationsAssignmentJob.perform_later(inbox_id)
+      end
+      render json: { success: true }, status: :ok
+    rescue StandardError => e
+      Rails.logger.error("Error in unassigned_conversations_assignment: #{e.message}")
+      render json: { error: 'An error occurred while processing the request' }, status: :internal_server_error
+    end
+  end
+
   def delete_messages_with_source_id
     messages = Message.where(account_id: params[:id], source_id: params[:source_id])
     if messages.empty?

--- a/app/javascript/dashboard/api/account.js
+++ b/app/javascript/dashboard/api/account.js
@@ -16,6 +16,13 @@ class AccountAPI extends ApiClient {
     );
     return response.data.cache_keys;
   }
+
+  async assignUnassignedConversations(inboxIds) {
+    return axios.post(
+      `/api/v1/accounts/${this.accountIdFromRoute}/unassigned_conversations_assignment`,
+      { inbox_ids: inboxIds }
+    );
+  }
 }
 
 export default new AccountAPI();

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -63,6 +63,23 @@
       @assign-labels="onAssignLabels"
       @assign-team="onAssignTeamsForBulk"
     />
+
+    <!-- if unassigned conversations are enabled -->
+    <div
+      v-if="showAssignButton"
+      class="flex justify-center items-center gap-4 py-2 px-4 bg-slate-100 dark:bg-slate-700"
+    >
+      <p class="text-xs m-0">
+        {{ activeAssigneeTabCount }} Unassigned Conversation(s) Available
+      </p>
+      <woot-button
+        variant="hollow"
+        class="text-xs"
+        @click="assignUnassignedConversations"
+      >
+        Assign to Online Agents
+      </woot-button>
+    </div>
     <div
       ref="conversationList"
       class="flex-1 conversations-list"
@@ -157,6 +174,7 @@ import { findSnoozeTime } from 'dashboard/helper/snoozeHelpers';
 import { getUnixTime } from 'date-fns';
 import CustomSnoozeModal from 'dashboard/components/CustomSnoozeModal.vue';
 import IntersectionObserver from './IntersectionObserver.vue';
+import AccountAPI from 'dashboard/api/account';
 
 export default {
   components: {
@@ -293,6 +311,12 @@ export default {
     },
     hasAppliedFiltersOrActiveFolders() {
       return this.hasAppliedFilters || this.hasActiveFolders;
+    },
+    showAssignButton() {
+      return (
+        this.activeAssigneeTab === wootConstants.ASSIGNEE_TYPE.UNASSIGNED &&
+        this.conversationList.length
+      );
     },
     showEndOfListMessage() {
       return (
@@ -1035,6 +1059,22 @@ export default {
       // Then if the custom snooze modal is closed and set the context menu chat id to null
       this.$store.dispatch('setContextMenuChatId', null);
       this.showCustomSnoozeModal = false;
+    },
+    assignUnassignedConversations() {
+      const inboxIds = [];
+      const url = window.location.href;
+      const ifInbox = url.includes('inbox');
+      if (ifInbox) {
+        inboxIds.push(url.split('inbox/')[1]);
+      } else {
+        const inboxes = this.$store.getters['inboxes/getInboxes'];
+        inboxIds.push(inboxes.map(inbox => inbox.id));
+      }
+      AccountAPI.assignUnassignedConversations(inboxIds);
+      this.showAlert(
+        'The conversations will soon be assigned to online agents.',
+        'info'
+      );
     },
   },
 };

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -27,6 +27,10 @@ class AccountPolicy < ApplicationPolicy
     true
   end
 
+  def unassigned_conversations_assignment?
+    true
+  end
+
   def subscription?
     @account_user.administrator?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
           get :cache_keys
           post :clear_billing_cache
           post :delete_messages_with_source_id
+          post :unassigned_conversations_assignment
         end
 
         scope module: :accounts do


### PR DESCRIPTION
## How
![image](https://github.com/user-attachments/assets/af6660a9-55bc-4888-a7d4-8248cc8b9137)

Will only be visible in the unassigned tab.

## Why

Implement a feature that allows users to assign all unassigned conversations to online agents, streamlining the communication process and improving response times. This change addresses the need for better workload distribution among agents.

## What

Introduce a new job, `UnassignedConversationsAssignmentJob`, to handle the assignment of unassigned conversations to online agents based on their availability. Modify the `AccountsController` to add an endpoint for triggering this job. Update the Vue component to include a button that enables users to initiate the assignment process. Ensure proper error handling and feedback to users during the assignment process.
