### PR TITLE
feat: add audio support for api inbox

### DIFF
--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -46,9 +46,12 @@ export const MAXIMUM_FILE_UPLOAD_SIZE_FOR_WHATSAPP = {
   '.m4a': 16,
   '.amr': 16,
   '.aac': 16,
+  '.opus': 16,
+  '.ogg': 16,
 };
 
-export const ALLOWED_FILE_TYPES = '.png,.jpeg,.mp4,.pdf,.mp3,.m4a,.amr,.aac';
+export const ALLOWED_FILE_TYPES =
+  '.png,.jpeg,.mp4,.pdf,.mp3,.m4a,.amr,.aac,.opus,.ogg';
 // 'image/*,' +
 // 'audio/*,' +
 // 'video/*,' +

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -42,9 +42,13 @@ export const MAXIMUM_FILE_UPLOAD_SIZE_FOR_WHATSAPP = {
   '.jpeg': 5,
   '.mp4': 16,
   '.pdf': 100,
+  '.mpeg': 16,
+  '.opus': 16,
+  '.ogg': 16,
+  '.amr': 16,
 };
 
-export const ALLOWED_FILE_TYPES = '.png,.jpeg,.mp4,.pdf';
+export const ALLOWED_FILE_TYPES = '.png,.jpeg,.mp4,.pdf,.mpeg,.opus,.ogg,.amr';
 // 'image/*,' +
 // 'audio/*,' +
 // 'video/*,' +

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -50,7 +50,7 @@ export const MAXIMUM_FILE_UPLOAD_SIZE_FOR_WHATSAPP = {
   '.ogg': 16,
 };
 
-export const ALLOWED_FILE_TYPES = '.png,.jpeg,.mp4,.pdf,.mp3,.m4a,.amr,.aac';
+export const ALLOWED_FILE_TYPES = '.png,.jpeg,.mp4,.pdf,.mp3,.m4a';
 // 'image/*,' +
 // 'audio/*,' +
 // 'video/*,' +

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -50,8 +50,7 @@ export const MAXIMUM_FILE_UPLOAD_SIZE_FOR_WHATSAPP = {
   '.ogg': 16,
 };
 
-export const ALLOWED_FILE_TYPES =
-  '.png,.jpeg,.mp4,.pdf,.mp3,.m4a,.amr,.aac,.opus,.ogg';
+export const ALLOWED_FILE_TYPES = '.png,.jpeg,.mp4,.pdf,.mp3,.m4a,.amr,.aac';
 // 'image/*,' +
 // 'audio/*,' +
 // 'video/*,' +

--- a/app/javascript/shared/constants/messages.js
+++ b/app/javascript/shared/constants/messages.js
@@ -42,13 +42,13 @@ export const MAXIMUM_FILE_UPLOAD_SIZE_FOR_WHATSAPP = {
   '.jpeg': 5,
   '.mp4': 16,
   '.pdf': 100,
-  '.mpeg': 16,
-  '.opus': 16,
-  '.ogg': 16,
+  '.mp3': 16,
+  '.m4a': 16,
   '.amr': 16,
+  '.aac': 16,
 };
 
-export const ALLOWED_FILE_TYPES = '.png,.jpeg,.mp4,.pdf,.mpeg,.opus,.ogg,.amr';
+export const ALLOWED_FILE_TYPES = '.png,.jpeg,.mp4,.pdf,.mp3,.m4a,.amr,.aac';
 // 'image/*,' +
 // 'audio/*,' +
 // 'video/*,' +


### PR DESCRIPTION
Added support for: .mpeg, .opus, .ogg, and .amr files

Enhance the API inbox functionality to support audio file uploads, addressing user requests for improved media handling. Add support for additional audio file types (including .mpeg, .opus, .ogg, and .amr) in the maximum file upload size constants and the allowed file types. Update the relevant constants to enable users to upload a broader range of media formats through the API inbox. 