### PR TITLE
feat: conversation marked an unread when assigning to an agent

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -833,6 +833,7 @@ export default {
         });
         this.$store.dispatch('bulkActions/clearSelectedConversationIds');
         if (conversationId) {
+          this.markAsUnread(conversationId);
           this.showAlert(
             this.$t(
               'CONVERSATION.CARD_CONTEXT_MENU.API.AGENT_ASSIGNMENT.SUCCESFUL',
@@ -904,6 +905,9 @@ export default {
           conversationId,
           teamId: team.id,
         });
+        if (conversationId) {
+          this.markAsUnread(conversationId);
+        }
         this.showAlert(
           this.$t(
             'CONVERSATION.CARD_CONTEXT_MENU.API.TEAM_ASSIGNMENT.SUCCESFUL',

--- a/app/javascript/dashboard/routes/dashboard/conversation/ConversationAction.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ConversationAction.vue
@@ -250,6 +250,7 @@ export default {
       } else {
         this.assignedAgent = selectedItem;
       }
+      // TODO: mark conversation as unread
     },
 
     onClickAssignTeam(selectedItemTeam) {
@@ -258,6 +259,7 @@ export default {
       } else {
         this.assignedTeam = selectedItemTeam;
       }
+      // TODO: mark conversation as unread
     },
 
     onClickAssignPriority(selectedPriorityItem) {

--- a/app/javascript/dashboard/routes/dashboard/conversation/ConversationAction.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ConversationAction.vue
@@ -90,6 +90,7 @@ import agentMixin from 'dashboard/mixins/agentMixin';
 import teamMixin from 'dashboard/mixins/conversation/teamMixin';
 import { CONVERSATION_PRIORITY } from '../../../../shared/constants/messages';
 import { CONVERSATION_EVENTS } from '../../../helper/AnalyticsHelper/events';
+import { conversationListPageURL } from '../../../helper/URLHelper';
 
 export default {
   components: {
@@ -244,6 +245,36 @@ export default {
       };
       this.assignedAgent = selfAssign;
     },
+    async markAsUnread(conversationId) {
+      try {
+        await this.$store.dispatch('markMessagesUnread', {
+          id: conversationId,
+        });
+        const {
+          params: { accountId, inbox_id: inboxId, label, teamId },
+        } = this.$route;
+        const isFolderView = window.location.pathname.includes('custom_view');
+        const customViewId = isFolderView
+          ? window.location.pathname
+              .split('/')
+              .find(
+                (segment, index, array) =>
+                  array[index - 1] === 'custom_view' && !Number.isNaN(segment)
+              )
+          : null;
+        this.$router.push(
+          conversationListPageURL({
+            accountId,
+            customViewId,
+            inboxId,
+            label,
+            teamId,
+          })
+        );
+      } catch (error) {
+        // Ignore error
+      }
+    },
     onClickAssignAgent(selectedItem) {
       if (this.assignedAgent && this.assignedAgent.id === selectedItem.id) {
         this.assignedAgent = null;
@@ -251,6 +282,7 @@ export default {
         this.assignedAgent = selectedItem;
       }
       // TODO: mark conversation as unread
+      this.markAsUnread(this.currentChat.id);
     },
 
     onClickAssignTeam(selectedItemTeam) {
@@ -260,6 +292,7 @@ export default {
         this.assignedTeam = selectedItemTeam;
       }
       // TODO: mark conversation as unread
+      this.markAsUnread(this.currentChat.id);
     },
 
     onClickAssignPriority(selectedPriorityItem) {


### PR DESCRIPTION
Add the `markAsUnread` method to the `ConversationAction` component, which dispatches an action to mark messages unread and updates the conversation list URL accordingly. This method is invoked when an agent or team is assigned to ensure the conversation receives the correct status. 
