### PR TITLE
pre-feat: ingest logic changes for new metrics

### DIFF
--- a/app/helpers/reporting_event_helper.rb
+++ b/app/helpers/reporting_event_helper.rb
@@ -26,6 +26,12 @@ module ReportingEventHelper
     handoff_event&.event_end_time || conversation.created_at
   end
 
+  def last_agent_assignment(conversation)
+    latest_agent_assignment = ConversationAssignment.where(conversation_id: conversation.id).last
+
+    latest_agent_assignment&.created_at || conversation.created_at
+  end
+
   private
 
   def configure_working_hours(working_hours)

--- a/app/listeners/reporting_event_listener.rb
+++ b/app/listeners/reporting_event_listener.rb
@@ -3,18 +3,18 @@ class ReportingEventListener < BaseListener
 
   def conversation_resolved(event)
     conversation = extract_conversation_and_account(event)[0]
-    time_to_resolve = conversation.updated_at.to_i - last_non_human_activity(conversation).to_i
+    time_to_resolve = conversation.updated_at.to_i - last_agent_assignment(conversation).to_i
 
     reporting_event = ReportingEvent.new(
       name: 'conversation_resolved',
       value: time_to_resolve,
-      value_in_business_hours: business_hours(conversation.inbox, last_non_human_activity(conversation),
+      value_in_business_hours: business_hours(conversation.inbox, last_agent_assignment(conversation),
                                               conversation.updated_at),
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
       user_id: conversation.assignee_id,
       conversation_id: conversation.id,
-      event_start_time: last_non_human_activity(conversation),
+      event_start_time: last_agent_assignment(conversation),
       event_end_time: conversation.updated_at
     )
 
@@ -25,18 +25,18 @@ class ReportingEventListener < BaseListener
   def first_reply_created(event)
     message = extract_message_and_account(event)[0]
     conversation = message.conversation
-    first_response_time = message.created_at.to_i - last_non_human_activity(conversation).to_i
+    first_response_time = message.created_at.to_i - last_agent_assignment(conversation).to_i
 
     reporting_event = ReportingEvent.new(
       name: 'first_response',
       value: first_response_time,
-      value_in_business_hours: business_hours(conversation.inbox, last_non_human_activity(conversation),
+      value_in_business_hours: business_hours(conversation.inbox, last_agent_assignment(conversation),
                                               message.created_at),
       account_id: conversation.account_id,
       inbox_id: conversation.inbox_id,
       user_id: message.sender_id,
       conversation_id: conversation.id,
-      event_start_time: last_non_human_activity(conversation),
+      event_start_time: last_agent_assignment(conversation),
       event_end_time: message.created_at
     )
 

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -101,6 +101,8 @@ class Conversation < ApplicationRecord
   has_one :csat_survey_response, dependent: :destroy_async
   has_many :conversation_participants, dependent: :destroy_async
   has_many :notifications, as: :primary_actor, dependent: :destroy_async
+  has_many :conversation_statuses, dependent: :destroy_async
+  has_many :conversation_assignments, dependent: :destroy_async
   has_many :attachments, through: :messages
 
   before_save :ensure_snooze_until_reset
@@ -110,6 +112,9 @@ class Conversation < ApplicationRecord
   after_update_commit :execute_after_update_commit_callbacks
   after_create_commit :notify_conversation_creation
   after_create_commit :load_attributes_created_by_db_triggers
+  after_create_commit :log_status_change
+  after_save :log_status_change, if: :saved_change_to_status?
+  after_save :log_assignment_change, if: :saved_change_to_assignee_id?
 
   delegate :auto_resolve_duration, to: :account
 
@@ -200,6 +205,28 @@ class Conversation < ApplicationRecord
   end
 
   private
+
+  def log_status_change
+    ConversationStatus.create!(
+      account_id: account_id,
+      inbox_id: inbox_id,
+      conversation_id: id,
+      status: status
+    )
+  end
+
+  def log_assignment_change
+    ConversationAssignment.create!(
+      account_id: account_id,
+      inbox_id: inbox_id,
+      conversation_id: id,
+      assignee_id: assignee_id,
+      team_id: team_id
+    )
+
+    # Clear first_reply_created_at when assignee changes
+    update(:first_reply_created_at, nil)
+  end
 
   def execute_after_update_commit_callbacks
     notify_status_change

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -225,7 +225,7 @@ class Conversation < ApplicationRecord
     )
 
     # Clear first_reply_created_at when assignee changes
-    update(:first_reply_created_at, nil)
+    update(first_reply_created_at: nil)
   end
 
   def execute_after_update_commit_callbacks

--- a/app/models/conversation_assignment.rb
+++ b/app/models/conversation_assignment.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: conversation_assignments
+#
+#  id              :bigint           not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  account_id      :bigint           not null
+#  assignee_id     :bigint           not null
+#  conversation_id :bigint           not null
+#  inbox_id        :bigint           not null
+#  team_id         :bigint
+#
+# Indexes
+#
+#  index_conversation_assignments_on_account_id       (account_id)
+#  index_conversation_assignments_on_assignee_id      (assignee_id)
+#  index_conversation_assignments_on_conversation_id  (conversation_id)
+#  index_conversation_assignments_on_inbox_id         (inbox_id)
+#  index_conversation_assignments_on_team_id          (team_id)
+#
+class ConversationAssignment < ApplicationRecord
+  validates :conversation, :account, :inbox, :assignee, presence: true
+
+  belongs_to :conversation
+  belongs_to :account
+  belongs_to :inbox
+  belongs_to :assignee, class_name: 'User'
+  belongs_to :team, optional: true
+end

--- a/app/models/conversation_status.rb
+++ b/app/models/conversation_status.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: conversation_statuses
+#
+#  id              :bigint           not null, primary key
+#  status          :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  account_id      :bigint           not null
+#  conversation_id :bigint           not null
+#  inbox_id        :bigint           not null
+#
+# Indexes
+#
+#  index_conversation_statuses_on_account_id                      (account_id)
+#  index_conversation_statuses_on_conversation_id                 (conversation_id)
+#  index_conversation_statuses_on_conversation_id_and_created_at  (conversation_id,created_at)
+#  index_conversation_statuses_on_inbox_id                        (inbox_id)
+#
+class ConversationStatus < ApplicationRecord
+  validates :account, :inbox, :conversation, :status, presence: true
+
+  belongs_to :account
+  belongs_to :inbox
+  belongs_to :conversation
+
+  enum status: { open: 0, resolved: 1, pending: 2, snoozed: 3 }
+
+  # Add any additional validations, scopes, or methods as needed
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -214,6 +214,7 @@ class Message < ApplicationRecord
     true
   end
 
+  # rubocop:disable Layout/LineLength
   def valid_first_reply?
     return false unless outgoing? && human_response? && !private?
     return false if conversation.first_reply_created_at.present?
@@ -221,10 +222,11 @@ class Message < ApplicationRecord
                                 .where.not(sender_type: 'AgentBot')
                                 .where.not(private: true)
                                 .where("(additional_attributes->'campaign_id') is null")
-                                .where("(additional_attributes->'ignore_automation_rules') is null").count > 1
+                                .where("(additional_attributes->'ignore_automation_rules') is null").where('created_at > ?', conversation.updated_at).count > 1
 
     true
   end
+  # rubocop:enable Layout/LineLength
 
   def save_story_info(story_info)
     self.content_attributes = content_attributes.merge(

--- a/db/migrate/20241018034459_create_conversation_statuses.rb
+++ b/db/migrate/20241018034459_create_conversation_statuses.rb
@@ -1,0 +1,13 @@
+class CreateConversationStatuses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :conversation_statuses do |t|
+      t.references :account, null: false, index: true
+      t.references :inbox, null: false, index: true
+      t.references :conversation, null: false, index: true
+      t.integer :status, null: false
+
+      t.index [:conversation_id, :created_at]
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241018040646_create_conversation_assignments.rb
+++ b/db/migrate/20241018040646_create_conversation_assignments.rb
@@ -1,0 +1,13 @@
+class CreateConversationAssignments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :conversation_assignments do |t|
+      t.references :conversation, null: false, index: true
+      t.references :account, null: false, index: true
+      t.references :inbox, null: false, index: true
+      t.references :assignee, null: false, index: true
+      t.references :team, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_16_003531) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_18_040646) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -435,6 +435,21 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_16_003531) do
     t.index ["phone_number", "account_id"], name: "index_contacts_on_phone_number_and_account_id"
   end
 
+  create_table "conversation_assignments", force: :cascade do |t|
+    t.bigint "conversation_id", null: false
+    t.bigint "account_id", null: false
+    t.bigint "inbox_id", null: false
+    t.bigint "assignee_id", null: false
+    t.bigint "team_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_conversation_assignments_on_account_id"
+    t.index ["assignee_id"], name: "index_conversation_assignments_on_assignee_id"
+    t.index ["conversation_id"], name: "index_conversation_assignments_on_conversation_id"
+    t.index ["inbox_id"], name: "index_conversation_assignments_on_inbox_id"
+    t.index ["team_id"], name: "index_conversation_assignments_on_team_id"
+  end
+
   create_table "conversation_participants", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.bigint "user_id", null: false
@@ -445,6 +460,19 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_16_003531) do
     t.index ["conversation_id"], name: "index_conversation_participants_on_conversation_id"
     t.index ["user_id", "conversation_id"], name: "index_conversation_participants_on_user_id_and_conversation_id", unique: true
     t.index ["user_id"], name: "index_conversation_participants_on_user_id"
+  end
+
+  create_table "conversation_statuses", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "inbox_id", null: false
+    t.bigint "conversation_id", null: false
+    t.integer "status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_conversation_statuses_on_account_id"
+    t.index ["conversation_id", "created_at"], name: "index_conversation_statuses_on_conversation_id_and_created_at"
+    t.index ["conversation_id"], name: "index_conversation_statuses_on_conversation_id"
+    t.index ["inbox_id"], name: "index_conversation_statuses_on_inbox_id"
   end
 
   create_table "conversations", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Add two new models, `ConversationAssignment` and `ConversationStatus`, to log changes in conversation ownership and status. Update existing methods in `ReportingEventListener` to utilize the timestamp of the latest agent assignment instead of the last non-human activity. Ensure that appropriate database migrations are in place to create the new tables.